### PR TITLE
Update documentation for multi-language support and API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Replaces a static Google Forms workflow with an AI agent that guides parents thr
 - Answers questions about fees, schedule, and policies from a curated knowledge base
 - Validates and stores completed registrations as structured data
 - Notifies playgroup administrators on completion, routed by playgroup type
-- Supports German and English; defaults to German
+- Responds in any language the parent uses; defaults to German
 
 ## Channels
 
@@ -45,13 +45,13 @@ cp .env.example .env
 | Variable | Description |
 |---|---|
 | `AI_MODEL` | litellm model string, e.g. `anthropic/claude-opus-4-6` or `openai/gpt-4o` |
-| `ANTHROPIC_API_KEY` | API key for Anthropic models |
-| `OPENAI_API_KEY` | API key for OpenAI models (if using OpenAI) |
 | `IMAP_HOST` | IMAP server hostname for receiving parent emails |
 | `IMAP_USERNAME` | Email account username |
 | `IMAP_PASSWORD` | Email account password |
 | `SMTP_HOST` | SMTP server hostname for sending replies |
 | `REGISTRATION_EMAIL` | Sender address shown to parents |
+
+The API key variable depends on your chosen provider — see [Switching AI providers](#switching-ai-providers) below.
 
 ### Optional variables
 


### PR DESCRIPTION
## Summary
Updated README documentation to reflect the agent's multi-language capabilities and improve clarity around API key configuration.

## Key Changes
- **Language support**: Updated feature description from "Supports German and English; defaults to German" to "Responds in any language the parent uses; defaults to German" to accurately reflect the agent's multi-language capabilities
- **API key documentation**: Removed hardcoded references to `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from the required variables table and replaced with a note directing users to provider-specific documentation, making the setup instructions more flexible and maintainable as providers change

## Notable Details
- The change acknowledges that API key variable names depend on the chosen AI provider, reducing confusion for users switching between providers
- Documentation now better reflects the actual capability of the system to handle any language input, not just German and English

https://claude.ai/code/session_01F9RoUQYKktPrmsvemSYrPk