### PR TITLE
Replace personal email addresses with generic placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,8 +62,8 @@ REGISTRATION_EMAIL=anmeldung@example.com
 # ADMIN_EMAIL_CC is always included as Cc (comma-separated for multiple).
 # For testing, point all three to your own email address.
 # ---------------------------------------------------------------
-ADMIN_EMAIL_INDOOR=andrea.sigrist@gmx.net
-ADMIN_EMAIL_OUTDOOR=baba.laeubli@gmail.com
+ADMIN_EMAIL_INDOOR=indoor-leader@example.com
+ADMIN_EMAIL_OUTDOOR=outdoor-leader@example.com
 ADMIN_EMAIL_CC=spielgruppen@familien-verein.ch
 
 # ---------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ uv run chainlit run chat_app.py --port 8080 --host 0.0.0.0
 | `ANTHROPIC_API_KEY` | (or the key for your chosen provider) |
 | `SMTP_HOST` / `SMTP_PORT` | For admin notification emails on registration completion |
 | `IMAP_USERNAME` / `IMAP_PASSWORD` | Used as SMTP credentials |
-| `ADMIN_EMAIL_INDOOR` | Andrea Sigrist — notified when indoor group is booked |
-| `ADMIN_EMAIL_OUTDOOR` | Barbara Gross — notified when outdoor group is booked |
-| `ADMIN_EMAIL_CC` | Markus Graf — always CC'd on notifications |
+| `ADMIN_EMAIL_INDOOR` | Indoor group leader — notified when indoor group is booked |
+| `ADMIN_EMAIL_OUTDOOR` | Outdoor group leader — notified when outdoor group is booked |
+| `ADMIN_EMAIL_CC` | Admin — always CC'd on notifications |
 
 IMAP variables (`IMAP_HOST`, etc.) are not required for the web chat — only for the email channel.
 


### PR DESCRIPTION
## Summary
Updated email configuration documentation and examples to use generic role-based placeholders instead of personal email addresses.

## Changes
- **README.md**: Updated environment variable descriptions to reference generic roles (Indoor group leader, Outdoor group leader, Admin) instead of specific individuals
- **.env.example**: Replaced personal email addresses with example domain placeholders:
  - `andrea.sigrist@gmx.net` → `indoor-leader@example.com`
  - `baba.laeubli@gmail.com` → `outdoor-leader@example.com`
  - Kept `spielgruppen@familien-verein.ch` as the CC email (organizational address)

## Details
This change improves the configuration template by:
- Making the example configuration more generic and reusable for other deployments
- Removing personal information from the repository
- Clarifying that these variables should be configured with appropriate role-based email addresses for each deployment

https://claude.ai/code/session_01Y6uFfnbjzxHoAYQYd2vyuS